### PR TITLE
Using if-else to limit the set of host for copying keys to nfs.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,11 @@
   become: False
   when: generate_ssh_known_hosts
 
+# minimize the set of hosts for copying if the step is skipped. Ansible will otherwise iterate over the entire set (and skip for each element).
+- name: store install_ssh_host_keys_to_nfs hosts to variable
+  set_fact:
+    copy_hosts: "{% if install_ssh_host_keys_to_nfs %} '{{ groups.compute }}' {% else %} '{{ ansible_hostname }}' {% endif %}"
+
 - include: ssh_host_keys_copy.yml
   tags: ssh_host_keys
   become: True

--- a/tasks/ssh_host_keys_copy.yml
+++ b/tasks/ssh_host_keys_copy.yml
@@ -3,7 +3,7 @@
 #Remote
 - name: create SSH host key directory in ssh_host_keys_dir - assumes a shared directory
   file: "path={{ ssh_host_keys_dir }}/{{ item }}/ssh/ state=directory mode=0750 owner=root group=admin"
-  with_items: "{{ groups.compute }}"
+  with_items: "{{ copy_hosts }}"
   when: generate_ssh_known_hosts
 
 - name: Ensure that the SSH known_hosts directory exists
@@ -29,7 +29,7 @@
         dest={{ ssh_host_keys_dir }}/{{ item[0] }}/ssh/{{ item[1] }} 
         owner=root group=admin mode=0640 backup=yes
   with_nested: 
-   - "{{ groups.compute }}"
+   - "{{ copy_hosts }}"
    - "{{ ssh_host_key_files }}"
   when: generate_ssh_known_hosts
 
@@ -38,6 +38,6 @@
         dest={{ ssh_host_keys_dir }}/{{ item[0] }}/ssh/{{ item[1] }}.pub 
         owner=root group=admin mode=0640 backup=yes
   with_nested: 
-   - "{{ groups.compute }}"
+   - "{{ copy_hosts }}"
    - "{{ ssh_host_key_files }}"
   when: generate_ssh_known_hosts


### PR DESCRIPTION
In normal case the copying of keys to nfs is usually skipped (ansible-pull). Yet, ansible iterates over all the groups.compute elements that is really slow if there are multiple nodes. Fixed this by setting the set to a single node when the copying is skipped. Will significantly speed up the ansible-pull.
